### PR TITLE
Change url helper to not add a protocol

### DIFF
--- a/lib/client_services.rb
+++ b/lib/client_services.rb
@@ -38,8 +38,7 @@ class ClientServices
     end
 
     define_method("#{service}_url") do |secure: false|
-      protocol = secure ? "https" : "http"
-      ENV["#{service.upcase}_URL"] || ("#{protocol}://" + send(:"#{service}_app_name") + ".herokuapp.com/")
+      ENV["#{service.upcase}_URL"] || ("//" + send(:"#{service}_app_name") + ".herokuapp.com/")
     end
   end
 end

--- a/spec/drops/widget_drop_spec.rb
+++ b/spec/drops/widget_drop_spec.rb
@@ -17,8 +17,8 @@ describe WidgetDrop do
   end
 
   describe "service URL helpers" do
-    its(:cpns_url) { should eq("http://g5-cpns-12345-test.herokuapp.com/") }
-    its(:secure_cpns_url) { should eq("https://g5-cpns-12345-test.herokuapp.com/") }
+    its(:cpns_url) { should eq("//g5-cpns-12345-test.herokuapp.com/") }
+    its(:secure_cpns_url) { should eq("//g5-cpns-12345-test.herokuapp.com/") }
   end
 
   describe "parent_widget_id" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,16 +1,16 @@
 require "spec_helper"
 
 describe ApplicationHelper do
-  
+
   describe "#image_tag_or_placeholder" do
     it "returns a placehold.it url" do
       helper.image_tag_or_placeholder(nil).should match "http://placehold.it/100x100"
     end
-    
+
     it "adds a placehold.it" do
       helper.image_tag_or_placeholder(nil, width: 200).should match "http://placehold.it/200x100"
     end
-    
+
     it "acts as a normal image_tag" do
       helper.image_tag('image.jpg').should match "/image.jpg"
     end
@@ -20,7 +20,7 @@ describe ApplicationHelper do
     before { Fabricate(:client, uid: "http://g5-hub.herokuapp.com/g5-c-12345-test") }
     subject { helper.leads_service_js }
 
-    it { should eq("https://g5-cls-12345-test.herokuapp.com/assets/form_enhancer.js") }
+    it { should eq("//g5-cls-12345-test.herokuapp.com/assets/form_enhancer.js") }
   end
 
   describe "user class methods" do

--- a/spec/lib/client_services_spec.rb
+++ b/spec/lib/client_services_spec.rb
@@ -70,7 +70,7 @@ describe ClientServices do
       describe "#{service}_url" do
         it "grabs the #{service}_url" do
           service_app_name = "g5-#{service}-irrelevant-clientname"[0...@heroku_app_max_length]
-          @client_services.send(:"#{service}_url").should == "http://#{service_app_name}.herokuapp.com/"
+          @client_services.send(:"#{service}_url").should == "//#{service_app_name}.herokuapp.com/"
         end
       end
     end
@@ -78,12 +78,12 @@ describe ClientServices do
     describe "service URL" do
       context "by default" do
         subject { @client_services.cls_url }
-        it { should eq("http://g5-cls-irrelevant-clientname.herokuapp.com/") }
+        it { should eq("//g5-cls-irrelevant-clientname.herokuapp.com/") }
       end
 
       context "passed secure: true" do
         subject { @client_services.cls_url(secure: true) }
-        it { should eq("https://g5-cls-irrelevant-clientname.herokuapp.com/") }
+        it { should eq("//g5-cls-irrelevant-clientname.herokuapp.com/") }
       end
     end
   end


### PR DESCRIPTION
I ran into an error where it was trying to pull a form across over http
on an https page and causing errors. So now it will just use the page's
protocol and hopefully avoid that issue in the future.